### PR TITLE
Added link to the webpage within the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Tux - A Boston Terrier's Website
 
-This is a demo website created as a five-part group project for CodeFellows Beginner Course 102.  It was created in collaboration with [Dan Quinn](https://www.linkedin.com/in/dan-quinn-70798726b/) to create a mock website showcasing his adorable dog named Tuxedo ("Tux").  The assignment instructions below were written by [CodeFellows](https://www.codefellows.org/) curriculum staff.
+🔗[Link to my page of this group project](https://myra-sea.github.io/HelloWorldDemo/)
+
+<br>
+
+This is a demo website created as a five-part group project for CodeFellows Beginner Course 102.  It was created in collaboration with [Dan Quinn](https://www.linkedin.com/in/dan-quinn-70798726b/) to create a mock website showcasing his adorable dog named Tuxedo ("Tux"). I created the page that is linked to here and Dan created the other page on it. The assignment instructions below were written by [CodeFellows](https://www.codefellows.org/) curriculum staff.
 
 <br>
 


### PR DESCRIPTION
Although it already appears underneath the "About" section to the side, for redundant ease of locating it I am adding a link to the live webpage within the README file itself as well.